### PR TITLE
Merge Dev into Main: Integrate dotenv Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("io.github.cdimascio:java-dotenv:5.2.2")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	runtimeOnly("com.mysql:mysql-connector-j")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/teamcaffeine/koja/KojaApplication.kt
+++ b/src/main/kotlin/com/teamcaffeine/koja/KojaApplication.kt
@@ -1,11 +1,19 @@
 package com.teamcaffeine.koja
 
+import io.github.cdimascio.dotenv.Dotenv
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import java.lang.System.setProperty
 
 @SpringBootApplication
 class KojaApplication
 
 fun main(args: Array<String>) {
+	val dotenv: Dotenv = Dotenv.load()
+
+	setProperty("KOJA_AWS_RDS_DATABASE_URL", dotenv["KOJA_AWS_RDS_DATABASE_URL"]!!)
+	setProperty("KOJA_AWS_RDS_DATABASE_ADMIN_USERNAME", dotenv["KOJA_AWS_RDS_DATABASE_ADMIN_USERNAME"]!!)
+	setProperty("KOJA_AWS_RDS_DATABASE_ADMIN_PASSWORD", dotenv["KOJA_AWS_RDS_DATABASE_ADMIN_PASSWORD"]!!)
+
 	runApplication<KojaApplication>(*args)
 }


### PR DESCRIPTION
This PR integrates dotenv support into the backend section (Spring Boot Kotlin) of the Koja system, improving the handling of environment-specific configurations and enhancing both security and convenience.

The changes include:

**Gradle Configuration File:**
- The `java-dotenv` library has been added as a dependency, facilitating the utilization of environment variables from a `.env` file within the application.

**Main Application File:**
- The `Dotenv` library is now used to load the `.env` file, setting the AWS RDS-related properties listed below as system properties. 

AWS RDS-related properties:
- database URL, 
- admin username, and 
- admin password
